### PR TITLE
Update for newer esphome

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,20 @@
+{
+    "MicroPython.executeButton": [
+        {
+            "text": "▶",
+            "tooltip": "Run",
+            "alignment": "left",
+            "command": "extension.executeFile",
+            "priority": 3.5
+        }
+    ],
+    "MicroPython.syncButton": [
+        {
+            "text": "$(sync)",
+            "tooltip": "sync",
+            "alignment": "left",
+            "command": "extension.execute",
+            "priority": 4
+        }
+    ]
+}

--- a/components/lc709203f/lc709203f.cpp
+++ b/components/lc709203f/lc709203f.cpp
@@ -357,11 +357,11 @@ int16_t LC709203FComponent::read16( uint8_t regAddress)
   uint8_t lowByteData;
   uint8_t highByteData;
   // Wire.beginTransmission(i2c_address);
-  this->write(regAddress,1);
+  this->write(&regAddress,1);
   // Wire.endTransmission(false);
   // Wire.requestFrom(i2c_address, (uint8_t)  2);   // jbo added per WEMOS_SHT3x_Arduino_Library issue 7
-  this->read(lowByteData,1);
-  this->read(highByteData,1);
+  this->read(&lowByteData,1);
+  this->read(&highByteData,1);
   data = word(highByteData, lowByteData);
   return( data );
 }

--- a/components/lc709203f/lc709203f.cpp
+++ b/components/lc709203f/lc709203f.cpp
@@ -28,6 +28,7 @@
 #include "esphome/core/log.h"
 
 #include "lc709203f.h"
+#include "Wire.h"
 
 namespace esphome {
 namespace lc709203f {

--- a/components/lc709203f/lc709203f.cpp
+++ b/components/lc709203f/lc709203f.cpp
@@ -27,8 +27,8 @@
 
 #include "esphome/core/log.h"
 
+
 #include "lc709203f.h"
-#include "Wire.h"
 
 namespace esphome {
 namespace lc709203f {
@@ -50,7 +50,7 @@ bool LC709203FComponent::begin( void )
 {
 
   ESP_LOGCONFIG( TAG, "Starting up LC709203F sensor");
-  Wire.begin();
+  // Wire.begin();
   setPowerMode(LC709203F_POWER_OPERATE) ;
   setTemperatureMode(LC709203F_TEMPERATURE_THERMISTOR) ;
 
@@ -69,7 +69,7 @@ bool LC709203FComponent::begin( void )
 void LC709203FComponent::setup() {
 
   ESP_LOGCONFIG( TAG, "Setting Up  LC709203F sensor");
-  Wire.begin();
+  // Wire.begin();
   setPowerMode(LC709203F_POWER_OPERATE) ;
   setTemperatureMode(LC709203F_TEMPERATURE_THERMISTOR) ;
   setCellCapacity(LC709203F_APA_2000MAH) ;    // jbo to suit the batery I am testing with
@@ -336,28 +336,32 @@ void LC709203FComponent::write16(uint8_t regAddress, uint16_t data)
   crcArray[3] = highByte(data);
   // Calculate crc of preceding four bytes and place in crcArray[4]
   crcArray[4] = crc8( crcArray, 4 );
-  // Device address
-  Wire.beginTransmission(i2c_address);
-  // Register address
-  Wire.write(regAddress);
-  // low byte
-  Wire.write(crcArray[2]);
-  // high byte
-  Wire.write(crcArray[3]);
-  // Send crc8 
-  Wire.write(crcArray[4]);
-  Wire.endTransmission();
+  // // Device address
+  // Wire.beginTransmission(i2c_address);
+  // // Register address
+  // Wire.write(regAddress);
+  this->write(&regAddress,1);
+  // // low byte
+  this->write(&crcArray[2],1);
+  // // high byte
+  this->write(&crcArray[3], 1);
+  // // Send crc8 
+  this->write(&crcArray[4],1);
+  // Wire.endTransmission();
+  
 }
 
 int16_t LC709203FComponent::read16( uint8_t regAddress)
 {
   int16_t data = 0;
-  Wire.beginTransmission(i2c_address);
-  Wire.write(regAddress);
-  Wire.endTransmission(false);
-  Wire.requestFrom(i2c_address, (uint8_t)  2);   // jbo added per WEMOS_SHT3x_Arduino_Library issue 7
-  uint8_t lowByteData = Wire.read();
-  uint8_t highByteData = Wire.read();
+  uint8_t lowByteData;
+  uint8_t highByteData;
+  // Wire.beginTransmission(i2c_address);
+  this->write(regAddress,1);
+  // Wire.endTransmission(false);
+  // Wire.requestFrom(i2c_address, (uint8_t)  2);   // jbo added per WEMOS_SHT3x_Arduino_Library issue 7
+  this->read(lowByteData,1);
+  this->read(highByteData,1);
   data = word(highByteData, lowByteData);
   return( data );
 }

--- a/components/lc709203f/sensor.py
+++ b/components/lc709203f/sensor.py
@@ -15,17 +15,17 @@ LC709203FComponent = lc709203f_ns.class_('LC709203FComponent', cg.PollingCompone
 CONFIG_SCHEMA = cv.Schema({
     cv.GenerateID(): cv.declare_id(LC709203FComponent),
     cv.Optional(CONF_BATTERY_VOLTAGE):
-        sensor.sensor_schema(UNIT_VOLT, ICON_EMPTY, 2).extend({
+        sensor.sensor_schema(unit_of_measurement=UNIT_VOLT, icon=ICON_EMPTY, accuracy_decimals=2).extend({
         }),
     cv.Optional(CONF_BATTERY_LEVEL):
-        sensor.sensor_schema(UNIT_PERCENT, ICON_EMPTY, 1).extend({
+        sensor.sensor_schema(unit_of_measurement=UNIT_PERCENT, icon=ICON_EMPTY, accuracy_decimals=1).extend({
         }),
     cv.Optional('cell_charge'):
-        sensor.sensor_schema(UNIT_PERCENT, ICON_EMPTY, 0).extend({
+        sensor.sensor_schema(unit_of_measurement=UNIT_PERCENT, icon=ICON_EMPTY, accuracy_decimals=0).extend({
         }),
     #cv.Optional('icversion'): cv.uint16_t,
     cv.Optional('icversion'):
-        sensor.sensor_schema(UNIT_EMPTY, ICON_EMPTY, 0).extend({
+        sensor.sensor_schema(unit_of_measurement=UNIT_EMPTY, icon=ICON_EMPTY, accuracy_decimals=0).extend({
         }),
 
 }).extend(cv.polling_component_schema('60s')).extend(i2c.i2c_device_schema(0x77))


### PR DESCRIPTION
Need to replace the usage of Arduino's `Wire.h` with the abstracted esphome i2c communication classes `i2c::I2CDevice`